### PR TITLE
Remove '$' character in onCopy method.

### DIFF
--- a/apps/playground/src/components/text/codeblock.tsx
+++ b/apps/playground/src/components/text/codeblock.tsx
@@ -17,7 +17,12 @@ export default function Codeblock({
   const [isMounted, setIsMounted] = useState(false);
 
   const { onCopy } = useClipboard(
-    isJson ? JSON.stringify(data, null, 2) : data,
+    isJson 
+      ? JSON.stringify(data, null, 2) 
+      : data
+        .split('\n')
+        .map(line => line.replace(/^\$\s*/, ''))
+        .join('\n')
   );
 
   function copy() {


### PR DESCRIPTION

## Summary

The change will allow to copy code from the code blocks without the leading `$`.

## Affect components

> Please indicate which part of the Mesh Repo

- [ ] `@meshsdk/common`
- [ ] `@meshsdk/contract`
- [ ] `@meshsdk/core`
- [ ] `@meshsdk/core-csl`
- [ ] `@meshsdk/core-cst`
- [ ] `@meshsdk/hydra`
- [ ] `@meshsdk/provider`
- [ ] `@meshsdk/react`
- [ ] `@meshsdk/svelte`
- [ ] `@meshsdk/transaction`
- [ ] `@meshsdk/wallet`
- [x] Mesh playground (i.e. <https://meshjs.dev/>)
- [ ] Mesh CLI

## Type of Change

> Please mark the relevant option(s) for your pull request:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (improving code quality without changing its behavior)
- [ ] Documentation update (adding or updating documentation related to the project)